### PR TITLE
Disable autofocus in kinh list bottom sheet

### DIFF
--- a/src/app/pages/kinh/components/kinh-detail/kinh-detail.component.ts
+++ b/src/app/pages/kinh/components/kinh-detail/kinh-detail.component.ts
@@ -243,6 +243,7 @@ export class KinhDetailComponent implements OnInit {
     this.bottomSheet.open(KinhListComponent, {
       panelClass: 'kinh-list-bottom-sheet',
       hasBackdrop: true,
+      autoFocus: false,
     });
   }
 }

--- a/src/app/pages/kinh/components/kinh-list/kinh-list.component.html
+++ b/src/app/pages/kinh/components/kinh-list/kinh-list.component.html
@@ -11,7 +11,7 @@
     <div class="search-section">
       <div class="search-container">
         <span class="search-icon material-icons">search</span>
-        <input type="text" placeholder="Tìm kiếm kinh..." #searchInput (input)="search(searchInput.value)"
+        <input type="text" [autofocus]="false" placeholder="Tìm kiếm kinh..." #searchInput (input)="search(searchInput.value)"
           class="search-input">
       </div>
     </div>


### PR DESCRIPTION
Set autoFocus to false when opening the KinhListComponent bottom sheet and updated the search input to not autofocus. This prevents the input from automatically receiving focus when the bottom sheet is opened.